### PR TITLE
Correct some weird comments in docker compose file

### DIFF
--- a/docker-compose/orion.yml
+++ b/docker-compose/orion.yml
@@ -74,10 +74,10 @@ services:
 
   # Keyrock is an Identity Management Front-End
   keyrock:
-    #labels:
+    labels:
       org.fiware: 'tutorial'
     image: fiware/idm:${KEYROCK_VERSION}
-    image: keyrock-slim
+    #image: keyrock-slim
     container_name: fiware-keyrock
     hostname: keyrock
     networks:
@@ -107,8 +107,8 @@ services:
 
   # PEP Proxy for Orion
   orion-proxy:
-    image: pep-slim
-    #labels:
+    #image: pep-slim
+    labels:
       org.fiware: 'tutorial'
     image: fiware/pep-proxy:${WILMA_VERSION}
     container_name: fiware-orion-proxy


### PR DESCRIPTION
There were some mistakes in the docker compose file regarding the creation of labels and duplicate images for PEP Proxy and Keyrock containers.